### PR TITLE
Bump policy_max CMake version to 3.31 to fix compatibility with CMake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license. See the accompanying LICENSE file for details.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...3.31)
 
 project(sharedlibpp
         VERSION 0.0.3


### PR DESCRIPTION
The soon to be released CMake 4.0 will raise an error for any project with `cmake_minimum_required(VERSION 3.5)`, as it removed support for having exactly the same behaviour of CMake 3.5 (see https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features).

To fix this, we add a `policy_max` argument to `cmake_minimum_required`, so that the project will remain compatible with CMake 3.5, but  we will use the CMake policy of up to CMake 3.31 (this is kind of equivalent of setting all policy introduced up to CMake 3.31 to `NEW`.
